### PR TITLE
feat: add accessible RTL chat widget, local history, hooks, and backend adapter

### DIFF
--- a/assets/icons/chat.svg
+++ b/assets/icons/chat.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2 3h20v14H6l-4 4z"/></svg>

--- a/assets/icons/close.svg
+++ b/assets/icons/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2"/></svg>

--- a/css/styles.css
+++ b/css/styles.css
@@ -711,3 +711,160 @@ body {
   outline: 2px solid var(--primary-dark);
   outline-offset: 2px;
 }
+
+/* Chatbot component */
+.chatbot-button {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  width: 56px;
+  height: 56px;
+  border: none;
+  border-radius: 50%;
+  background: var(--primary-gold);
+  color: var(--primary-dark);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+  z-index: 1000;
+}
+html[dir="rtl"] .chatbot-button {
+  right: 1rem;
+}
+@media (max-width: 600px) {
+  .chatbot-button {
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+  }
+}
+.chatbot-button:focus {
+  outline: 2px solid var(--primary-dark);
+  outline-offset: 2px;
+}
+
+.chatbot {
+  position: fixed;
+  right: 1rem;
+  bottom: 80px;
+  width: 320px;
+  max-height: 70vh;
+  display: flex;
+  flex-direction: column;
+  background: var(--primary-light);
+  color: var(--text-dark);
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+@media (max-width: 600px) {
+  .chatbot {
+    width: 90%;
+    right: 50%;
+    transform: translateX(50%);
+  }
+}
+
+.chatbot__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: var(--primary-dark);
+  color: var(--text-light);
+  border-radius: 8px 8px 0 0;
+}
+.chatbot__title {
+  margin: 0;
+  font-size: 1rem;
+}
+.chatbot__close {
+  background: none;
+  border: none;
+  color: var(--text-light);
+  cursor: pointer;
+}
+.chatbot__messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+.chatbot__message {
+  margin-bottom: 0.5rem;
+}
+.chatbot__message--user {
+  text-align: right;
+}
+.chatbot__time {
+  display: block;
+  font-size: 0.75rem;
+  color: #666;
+}
+.chatbot__form {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-top: 1px solid #ddd;
+}
+.chatbot__input {
+  flex: 1;
+  resize: none;
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+.chatbot__send,
+.chatbot__clear {
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+.chatbot__send {
+  background: var(--primary-gold);
+  color: var(--primary-dark);
+}
+.chatbot__clear {
+  background: var(--accent-red);
+  color: #fff;
+}
+.chatbot__send:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.chatbot__offline {
+  background: #fee;
+  color: #b91c1c;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  font-size: 0.875rem;
+}
+.chatbot__typing {
+  font-style: italic;
+  color: #666;
+}
+@media (prefers-reduced-motion: reduce) {
+  .chatbot,
+  .chatbot-button {
+    transition: none;
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .chatbot {
+    background: var(--primary-dark);
+    color: var(--text-light);
+    border-color: #555;
+  }
+  .chatbot__header {
+    background: var(--primary-gold);
+    color: var(--primary-dark);
+  }
+  .chatbot__input {
+    background: #333;
+    color: #fff;
+    border-color: #555;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1466,59 +1466,58 @@
         </div>
       </div>
     </div>
-    <!-- Chatbot Widget -->
-    <div class="chat-widget-button" id="chat-widget-button">
-      <img
-        alt="Chat Icon"
-        src="https://images.unsplash.com/photo-1574624816427-c9a631293c3e?ixlib=rb-4.0.3&amp;auto=format&amp;fit=crop&amp;w=100&amp;q=80"
-        loading="lazy"
-        decoding="async"
-        width="600"
-        height="400"
-        srcset="
-          https://images.unsplash.com/photo-1574624816427-c9a631293c3e?ixlib=rb-4.0.3&amp;auto=format&amp;fit=crop&amp;w=100&amp;q=80         1x,
-          https://images.unsplash.com/photo-1574624816427-c9a631293c3e?ixlib=rb-4.0.3&amp;auto=format&amp;fit=crop&amp;w=100&amp;q=80&fm=webp 1x
-        "
-      />
-    </div>
-    <div class="chat-container" id="chat-container">
-      <div class="chat-header">
-        <h3>مساعدك الذكي</h3>
-        <div class="flex items-center">
-          <button
-            class="reset-btn"
-            id="reset-chat-btn"
-            title="بدء محادثة جديدة"
-          >
-            <i class="fas fa-redo"></i>
-          </button>
-          <button class="close-btn" id="close-chat-btn">×</button>
-        </div>
-      </div>
-      <div class="chat-messages" id="chat-messages">
-        <!-- Messages will be appended here -->
-      </div>
-      <div class="chat-options" id="chat-options">
-        <!-- Initial options will be appended here -->
-      </div>
-      <form class="chat-input-form" id="chat-input-form">
-        <input
-          autocomplete="off"
-          id="chat-input"
-          placeholder="اكتب رسالتك هنا..."
-          type="text"
-        />
-        <button id="mic-btn" type="button">
-          <i class="fas fa-microphone"></i>
+    <button
+      class="chatbot-button"
+      id="chat-button"
+      aria-label="Open chat"
+    >
+      <img src="assets/icons/chat.svg" alt="" />
+    </button>
+    <div
+      class="chatbot"
+      id="chat-dialog"
+      role="dialog"
+      aria-modal="true"
+      hidden
+    >
+      <div class="chatbot__header">
+        <h2 class="chatbot__title">المساعد الذكي</h2>
+        <button class="chatbot__close" aria-label="إغلاق">
+          <img src="assets/icons/close.svg" alt="" />
         </button>
-        <button type="submit"><i class="fas fa-paper-plane"></i></button>
+      </div>
+      <div id="chat-offline" class="chatbot__offline" hidden>
+        ⚠️ لا يوجد اتصال بالإنترنت
+      </div>
+      <div
+        id="chat-messages"
+        class="chatbot__messages"
+        aria-live="polite"
+      ></div>
+      <form id="chat-form" class="chatbot__form">
+        <textarea
+          id="chat-input"
+          class="chatbot__input"
+          rows="1"
+          placeholder="اكتب رسالتك..."
+          aria-label="اكتب رسالتك"
+        ></textarea>
+        <button type="submit" id="chat-send" class="chatbot__send">
+          إرسال
+        </button>
+        <button type="button" id="chat-clear" class="chatbot__clear">
+          مسح
+        </button>
       </form>
     </div>
-    <!-- Floating Action Button -->
-    <div class="floating-action-btn" title="اتصل بنا">
-      <i class="fas fa-phone-alt"></i>
-    </div>
-
-    <script defer="True" src="js/app.js"></script>
+    <script type="module" defer src="js/app.js"></script>
+    <!--
+      Testing Checklist:
+      - Keyboard only flow works
+      - Mobile viewport renders without overflow
+      - Offline banner blocks send
+      - History persists across reloads
+      - Events logged
+    -->
   </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -911,3 +911,36 @@ document.addEventListener("DOMContentLoaded", () => {
     micBtn.style.display = "none";
   }
 });
+
+// Chatbot widget wiring
+let chatbotInstance;
+const chatButton = document.getElementById('chat-button');
+const chatContainer = document.getElementById('chat-dialog');
+
+function loadChatbot() {
+  if (chatbotInstance) return Promise.resolve(chatbotInstance);
+  return import('./chatbot.js').then(({ ChatBot }) => {
+    chatbotInstance = new ChatBot(chatContainer);
+    chatbotInstance.init();
+    return chatbotInstance;
+  });
+}
+
+if (chatButton) {
+  chatButton.addEventListener('click', () => {
+    loadChatbot().then((bot) => bot.open());
+  });
+}
+
+window.addEventListener('keydown', (e) => {
+  if (e.key === '?' && chatContainer.hidden) {
+    e.preventDefault();
+    loadChatbot().then((bot) => bot.open());
+  }
+});
+
+document.addEventListener('chat:open', () => console.log('chat:open'));
+document.addEventListener('chat:message', (e) =>
+  console.log('chat:message', e.detail),
+);
+document.addEventListener('chat:close', () => console.log('chat:close'));

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -1,0 +1,195 @@
+// Chatbot configuration
+export const CONFIG = {
+  BACKEND_URL: '/api/chat',
+  ENABLE_BACKEND: false,
+};
+
+export async function callBackend(messages) {
+  if (CONFIG.ENABLE_BACKEND) {
+    try {
+      const res = await fetch(CONFIG.BACKEND_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        return data.reply || '';
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  const last = messages[messages.length - 1];
+  return `تلقيت: ${last.text}`;
+}
+
+export class ChatBot {
+  constructor(root) {
+    this.root = root;
+    this.messagesEl = root.querySelector('#chat-messages');
+    this.form = root.querySelector('#chat-form');
+    this.input = root.querySelector('#chat-input');
+    this.sendBtn = root.querySelector('#chat-send');
+    this.clearBtn = root.querySelector('#chat-clear');
+    this.closeBtn = root.querySelector('.chatbot__close');
+    this.offlineEl = root.querySelector('#chat-offline');
+    this.historyKey = 'chat_history_v1';
+    this.nameKey = 'chat_user_name';
+    this.history = [];
+    this.offlineQueue = [];
+    this.rateTimes = [];
+    this.userName = localStorage.getItem(this.nameKey) || '';
+  }
+
+  init() {
+    this.loadHistory();
+    this.form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const text = this.input.value.trim();
+      if (!text) return;
+      this.sendUserMessage(text);
+      this.input.value = '';
+    });
+    this.clearBtn.addEventListener('click', () => this.clear());
+    this.closeBtn.addEventListener('click', () => this.close());
+    this.root.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') this.close();
+      if (e.key === 'Tab') this.trapFocus(e);
+    });
+    window.addEventListener('offline', () => this.updateOnline(false));
+    window.addEventListener('online', () => this.updateOnline(true));
+    this.updateOnline(navigator.onLine);
+  }
+
+  open() {
+    this.root.hidden = false;
+    this.input.focus();
+    document.dispatchEvent(new CustomEvent('chat:open'));
+  }
+
+  close() {
+    this.root.hidden = true;
+    document.getElementById('chat-button').focus();
+    document.dispatchEvent(new CustomEvent('chat:close'));
+  }
+
+  trapFocus(e) {
+    const focusables = this.root.querySelectorAll('button,textarea');
+    if (!focusables.length) return;
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  async sendUserMessage(text) {
+    const now = Date.now();
+    this.rateTimes = this.rateTimes.filter((t) => now - t < 10000);
+    if (this.rateTimes.length >= 5) {
+      this.renderMessage({ role: 'bot', text: 'يرجى الانتظار قبل إرسال المزيد من الرسائل.', time: new Date() });
+      return;
+    }
+    this.rateTimes.push(now);
+
+    this.renderMessage({ role: 'user', text, time: new Date() });
+    document.dispatchEvent(new CustomEvent('chat:message', { detail: { text } }));
+    if (!navigator.onLine) {
+      this.offlineQueue.push(text);
+      this.renderMessage({ role: 'bot', text: 'لا يوجد اتصال بالإنترنت. سيتم إرسال الرسالة لاحقاً.', time: new Date() });
+      return;
+    }
+    await this.respond(text);
+  }
+
+  async respond(text) {
+    this.showTyping();
+    let reply = this.routeFAQ(text);
+    if (!reply) {
+      reply = await callBackend(this.history);
+      if (!reply) {
+        reply = 'سأعود لك بإجابة… أرسل لنا على البريد example@example.com';
+      }
+    }
+    this.hideTyping();
+    this.renderMessage({ role: 'bot', text: reply, time: new Date() });
+  }
+
+  routeFAQ(text) {
+    const map = {
+      'أوقات العمل': 'أوقات العمل من ٩ صباحاً إلى ٥ مساءً.',
+      'الأسعار': 'تختلف الأسعار حسب الخدمة المطلوبة.',
+      'باقات العمرة': 'نوفر باقات عمرة متعددة تناسب الجميع.',
+      'طرق التواصل': 'تواصل معنا عبر الهاتف أو البريد الإلكتروني.',
+      'حالة الطلب': 'لمعرفة حالة الطلب يرجى تزويدنا برقم الطلب.',
+    };
+    const key = Object.keys(map).find((k) => text.includes(k));
+    if (key) return map[key];
+    if (!this.userName) {
+      const m = text.match(/اسمي\s+(\S+)/);
+      if (m) {
+        this.userName = m[1];
+        localStorage.setItem(this.nameKey, this.userName);
+        return `تشرفت بمعرفتك يا ${this.userName}!`;
+      }
+    }
+    return null;
+  }
+
+  renderMessage(msg) {
+    const el = document.createElement('div');
+    el.className = `chatbot__message chatbot__message--${msg.role}`;
+    const time = msg.time instanceof Date ? msg.time : new Date(msg.time);
+    el.innerHTML = `<span>${msg.text}</span><span class="chatbot__time">${time.toLocaleTimeString('ar-SA',{hour:'2-digit',minute:'2-digit'})}</span>`;
+    this.messagesEl.appendChild(el);
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+    this.history.push({ role: msg.role, text: msg.text, time: time.toISOString() });
+    this.history = this.history.slice(-20);
+    localStorage.setItem(this.historyKey, JSON.stringify(this.history));
+  }
+
+  showTyping() {
+    this.typingEl = document.createElement('div');
+    this.typingEl.className = 'chatbot__typing';
+    this.typingEl.textContent = '...';
+    this.messagesEl.appendChild(this.typingEl);
+    this.messagesEl.scrollTop = this.messagesEl.scrollHeight;
+  }
+
+  hideTyping() {
+    if (this.typingEl) {
+      this.typingEl.remove();
+      this.typingEl = null;
+    }
+  }
+
+  loadHistory() {
+    try {
+      const data = JSON.parse(localStorage.getItem(this.historyKey) || '[]');
+      data.forEach((m) => this.renderMessage(m));
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  clear() {
+    this.messagesEl.innerHTML = '';
+    this.history = [];
+    localStorage.removeItem(this.historyKey);
+  }
+
+  updateOnline(online) {
+    this.sendBtn.disabled = !online;
+    this.offlineEl.hidden = online;
+    if (online && this.offlineQueue.length) {
+      const q = [...this.offlineQueue];
+      this.offlineQueue = [];
+      q.forEach((t) => this.sendUserMessage(t));
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add floating chat button and modal with Arabic RTL support
- implement ChatBot class with localStorage history and backend adapter
- style chatbot component and wire custom analytics events

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad002dfa58832d9c8d0d7c183f0c5b